### PR TITLE
Fix sparse_nmf overflow-buffer bug on chunks past leading zero rows (#25)

### DIFF
--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -90,6 +90,85 @@ function rho(beta; root=false)
     return Float32(new_beta)
 end
 
+# Stream-reading helpers for chunked sparse / bincoo input.
+# Returns (count, overflow_buf). If `overflow_buf` already holds an entry whose
+# row is past the current chunk (which happens whenever the chunk range falls
+# entirely inside an empty region of the input — e.g. leading zero rows), we
+# leave it untouched and skip reading from the stream so the entry isn't
+# overwritten and is preserved for a later chunk.
+function read_sparse_chunk!(
+    rows::Vector{UInt32},
+    cols::Vector{UInt32},
+    vals::Vector{UInt32},
+    stream,
+    overflow_buf::Vector{UInt32},
+    n::Integer,
+    batch_size::Integer,
+)
+    count = 0
+    if length(overflow_buf) > 0
+        if n ≤ overflow_buf[1] < n + batch_size
+            count += 1
+            rows[count] = overflow_buf[1] - n + 1
+            cols[count] = overflow_buf[2]
+            vals[count] = overflow_buf[3]
+            empty!(overflow_buf)
+        else
+            return count, overflow_buf
+        end
+    end
+    while !eof(stream)
+        buf = zeros(UInt32, 3)
+        read!(stream, buf)
+        row, col, val = buf[1], buf[2], buf[3]
+        if n ≤ row < n + batch_size
+            count += 1
+            rows[count] = row - n + 1
+            cols[count] = col
+            vals[count] = val
+        else
+            overflow_buf = buf
+            return count, overflow_buf
+        end
+    end
+    return count, overflow_buf
+end
+
+function read_bincoo_chunk!(
+    rows::Vector{UInt32},
+    cols::Vector{UInt32},
+    stream,
+    overflow_buf::Vector{UInt32},
+    n::Integer,
+    batch_size::Integer,
+)
+    count = 0
+    if length(overflow_buf) > 0
+        if n ≤ overflow_buf[1] < n + batch_size
+            count += 1
+            rows[count] = overflow_buf[1] - n + 1
+            cols[count] = overflow_buf[2]
+            empty!(overflow_buf)
+        else
+            return count, overflow_buf
+        end
+    end
+    while !eof(stream)
+        buf = zeros(UInt32, 2)
+        read!(stream, buf)
+        row, col = buf[1], buf[2]
+        if n ≤ row < n + batch_size
+            count += 1
+            rows[count] = row - n + 1
+            cols[count] = col
+        else
+            overflow_buf = buf
+            return count, overflow_buf
+        end
+    end
+    return count, overflow_buf
+end
+
 # Check NaN value
 function checkNaN(X::AbstractArray)
     if any(isnan, X)
@@ -399,32 +478,7 @@ function RecError(
             rows = zeros(UInt32, max_size)
             cols = zeros(UInt32, max_size)
             vals = zeros(UInt32, max_size)
-            count = 0
-            ############### Overflow buffer ###############
-            if length(overflow_buf) > 0
-                count += 1
-                # Re-mapping row index
-                rows[count] = overflow_buf[1] - n + 1
-                cols[count] = overflow_buf[2]
-                vals[count] = overflow_buf[3]
-                empty!(overflow_buf)
-            end
-            ###############################################
-            while !eof(stream)
-                buf = zeros(UInt32, 3)
-                read!(stream, buf)
-                row, col, val = buf[1], buf[2], buf[3]
-                if n ≤ row < n + batch_size
-                    count += 1
-                    # Re-mapping row index
-                    rows[count] = row - n + 1
-                    cols[count] = col
-                    vals[count] = val
-                else
-                    overflow_buf = buf
-                    break
-                end
-            end
+            count, overflow_buf = read_sparse_chunk!(rows, cols, vals, stream, overflow_buf, n, batch_size)
             # Remove 0s from the end
             resize!(rows, count)
             resize!(cols, count)
@@ -466,30 +520,7 @@ function RecError(
             max_size = (batch_size + 1) * M # For overflow
             rows = zeros(UInt32, max_size)
             cols = zeros(UInt32, max_size)
-            count = 0
-            ############### Overflow buffer ###############
-            if length(overflow_buf) > 0
-                count += 1
-                # Re-mapping row index
-                rows[count] = overflow_buf[1] - n + 1
-                cols[count] = overflow_buf[2]
-                empty!(overflow_buf)
-            end
-            ###############################################
-            while !eof(stream)
-                buf = zeros(UInt32, 2)
-                read!(stream, buf)
-                row, col = buf[1], buf[2]
-                if n ≤ row < n + batch_size
-                    count += 1
-                    # Re-mapping row index
-                    rows[count] = row - n + 1
-                    cols[count] = col
-                else
-                    overflow_buf = buf
-                    break
-                end
-            end
+            count, overflow_buf = read_bincoo_chunk!(rows, cols, stream, overflow_buf, n, batch_size)
             # Remove 0s from the end
             resize!(rows, count)
             resize!(cols, count)

--- a/src/bincoo_dnmf.jl
+++ b/src/bincoo_dnmf.jl
@@ -204,30 +204,7 @@ function update_bcdU_numer_BETA(input, N, M, U, V, beta, binu, teru, chunksize)
             max_size = (batch_size + 1) * M # For overflow
             rows = zeros(UInt32, max_size)
             cols = zeros(UInt32, max_size)
-            count = 0
-            ############### Overflow buffer ###############
-            if length(overflow_buf) > 0
-                count += 1
-                # Re-mapping row index
-                rows[count] = overflow_buf[1] - n + 1
-                cols[count] = overflow_buf[2]
-                empty!(overflow_buf)
-            end
-            ###############################################
-            while !eof(stream)
-                buf = zeros(UInt32, 2)
-                read!(stream, buf)
-                row, col = buf[1], buf[2]
-                if n ≤ row < n + batch_size
-                    count += 1
-                    # Re-mapping row index
-                    rows[count] = row - n + 1
-                    cols[count] = col
-                else
-                    overflow_buf = buf
-                    break
-                end
-            end
+            count, overflow_buf = read_bincoo_chunk!(rows, cols, stream, overflow_buf, n, batch_size)
             # Remove 0s from the end
             resize!(rows, count)
             resize!(cols, count)
@@ -272,30 +249,7 @@ function update_bcdV_numer_BETA(input, N, M, U, V, beta, binv, terv, chunksize)
             max_size = (batch_size + 1) * M # For overflow
             rows = zeros(UInt32, max_size)
             cols = zeros(UInt32, max_size)
-            count = 0
-            ############### Overflow buffer ###############
-            if length(overflow_buf) > 0
-                count += 1
-                # Re-mapping row index
-                rows[count] = overflow_buf[1] - n + 1
-                cols[count] = overflow_buf[2]
-                empty!(overflow_buf)
-            end
-            ###############################################
-            while !eof(stream)
-                buf = zeros(UInt32, 2)
-                read!(stream, buf)
-                row, col = buf[1], buf[2]
-                if n ≤ row < n + batch_size
-                    count += 1
-                    # Re-mapping row index
-                    rows[count] = row - n + 1
-                    cols[count] = col
-                else
-                    overflow_buf = buf
-                    break
-                end
-            end
+            count, overflow_buf = read_bincoo_chunk!(rows, cols, stream, overflow_buf, n, batch_size)
             # Remove 0s from the end
             resize!(rows, count)
             resize!(cols, count)

--- a/src/bincoo_nmf.jl
+++ b/src/bincoo_nmf.jl
@@ -196,30 +196,7 @@ function update_bcU_numer_ALPHA(input, N, M, U, V, alpha, chunksize)
             max_size = (batch_size + 1) * M # For overflow
             rows = zeros(UInt32, max_size)
             cols = zeros(UInt32, max_size)
-            count = 0
-            ############### Overflow buffer ###############
-            if length(overflow_buf) > 0
-                count += 1
-                # Re-mapping row index
-                rows[count] = overflow_buf[1] - n + 1
-                cols[count] = overflow_buf[2]
-                empty!(overflow_buf)
-            end
-            ###############################################
-            while !eof(stream)
-                buf = zeros(UInt32, 2)
-                read!(stream, buf)
-                row, col = buf[1], buf[2]
-                if n ≤ row < n + batch_size
-                    count += 1
-                    # Re-mapping row index
-                    rows[count] = row - n + 1
-                    cols[count] = col
-                else
-                    overflow_buf = buf
-                    break
-                end
-            end
+            count, overflow_buf = read_bincoo_chunk!(rows, cols, stream, overflow_buf, n, batch_size)
             # Remove 0s from the end
             resize!(rows, count)
             resize!(cols, count)
@@ -260,30 +237,7 @@ function update_bcU_numer_BETA(input, N, M, U, V, beta, chunksize)
             max_size = (batch_size + 1) * M # For overflow
             rows = zeros(UInt32, max_size)
             cols = zeros(UInt32, max_size)
-            count = 0
-            ############### Overflow buffer ###############
-            if length(overflow_buf) > 0
-                count += 1
-                # Re-mapping row index
-                rows[count] = overflow_buf[1] - n + 1
-                cols[count] = overflow_buf[2]
-                empty!(overflow_buf)
-            end
-            ###############################################
-            while !eof(stream)
-                buf = zeros(UInt32, 2)
-                read!(stream, buf)
-                row, col = buf[1], buf[2]
-                if n ≤ row < n + batch_size
-                    count += 1
-                    # Re-mapping row index
-                    rows[count] = row - n + 1
-                    cols[count] = col
-                else
-                    overflow_buf = buf
-                    break
-                end
-            end
+            count, overflow_buf = read_bincoo_chunk!(rows, cols, stream, overflow_buf, n, batch_size)
             # Remove 0s from the end
             resize!(rows, count)
             resize!(cols, count)
@@ -339,30 +293,7 @@ function update_bcV_numer_ALPHA(input, N, M, U, V, alpha, chunksize)
             max_size = (batch_size + 1) * M # For overflow
             rows = zeros(UInt32, max_size)
             cols = zeros(UInt32, max_size)
-            count = 0
-            ############### Overflow buffer ###############
-            if length(overflow_buf) > 0
-                count += 1
-                # Re-mapping row index
-                rows[count] = overflow_buf[1] - n + 1
-                cols[count] = overflow_buf[2]
-                empty!(overflow_buf)
-            end
-            ###############################################
-            while !eof(stream)
-                buf = zeros(UInt32, 2)
-                read!(stream, buf)
-                row, col = buf[1], buf[2]
-                if n ≤ row < n + batch_size
-                    count += 1
-                    # Re-mapping row index
-                    rows[count] = row - n + 1
-                    cols[count] = col
-                else
-                    overflow_buf = buf
-                    break
-                end
-            end
+            count, overflow_buf = read_bincoo_chunk!(rows, cols, stream, overflow_buf, n, batch_size)
             # Remove 0s from the end
             resize!(rows, count)
             resize!(cols, count)
@@ -417,30 +348,7 @@ function update_bcV_numer_BETA(input, N, M, U, V, beta, chunksize)
             max_size = (batch_size + 1) * M # For overflow
             rows = zeros(UInt32, max_size)
             cols = zeros(UInt32, max_size)
-            count = 0
-            ############### Overflow buffer ###############
-            if length(overflow_buf) > 0
-                count += 1
-                # Re-mapping row index
-                rows[count] = overflow_buf[1] - n + 1
-                cols[count] = overflow_buf[2]
-                empty!(overflow_buf)
-            end
-            ###############################################
-            while !eof(stream)
-                buf = zeros(UInt32, 2)
-                read!(stream, buf)
-                row, col = buf[1], buf[2]
-                if n ≤ row < n + batch_size
-                    count += 1
-                    # Re-mapping row index
-                    rows[count] = row - n + 1
-                    cols[count] = col
-                else
-                    overflow_buf = buf
-                    break
-                end
-            end
+            count, overflow_buf = read_bincoo_chunk!(rows, cols, stream, overflow_buf, n, batch_size)
             # Remove 0s from the end
             resize!(rows, count)
             resize!(cols, count)

--- a/src/sparse_dnmf.jl
+++ b/src/sparse_dnmf.jl
@@ -205,32 +205,7 @@ function update_spdU_numer_BETA(input, N, M, U, V, beta, binu, teru, chunksize)
             rows = zeros(UInt32, max_size)
             cols = zeros(UInt32, max_size)
             vals = zeros(UInt32, max_size)
-            count = 0
-            ############### Overflow buffer ###############
-            if length(overflow_buf) > 0
-                count += 1
-                # Re-mapping row index
-                rows[count] = overflow_buf[1] - n + 1
-                cols[count] = overflow_buf[2]
-                vals[count] = overflow_buf[3]
-                empty!(overflow_buf)
-            end
-            ###############################################
-            while !eof(stream)
-                buf = zeros(UInt32, 3)
-                read!(stream, buf)
-                row, col, val = buf[1], buf[2], buf[3]
-                if n ≤ row < n + batch_size
-                    count += 1
-                    # Re-mapping row index
-                    rows[count] = row - n + 1
-                    cols[count] = col
-                    vals[count] = val
-                else
-                    overflow_buf = buf
-                    break
-                end
-            end
+            count, overflow_buf = read_sparse_chunk!(rows, cols, vals, stream, overflow_buf, n, batch_size)
             # Remove 0s from the end
             resize!(rows, count)
             resize!(cols, count)
@@ -277,32 +252,7 @@ function update_spdV_numer_BETA(input, N, M, U, V, beta, binv, terv, chunksize)
             rows = zeros(UInt32, max_size)
             cols = zeros(UInt32, max_size)
             vals = zeros(UInt32, max_size)
-            count = 0
-            ############### Overflow buffer ###############
-            if length(overflow_buf) > 0
-                count += 1
-                # Re-mapping row index
-                rows[count] = overflow_buf[1] - n + 1
-                cols[count] = overflow_buf[2]
-                vals[count] = overflow_buf[3]
-                empty!(overflow_buf)
-            end
-            ###############################################
-            while !eof(stream)
-                buf = zeros(UInt32, 3)
-                read!(stream, buf)
-                row, col, val = buf[1], buf[2], buf[3]
-                if n ≤ row < n + batch_size
-                    count += 1
-                    # Re-mapping row index
-                    rows[count] = row - n + 1
-                    cols[count] = col
-                    vals[count] = val
-                else
-                    overflow_buf = buf
-                    break
-                end
-            end
+            count, overflow_buf = read_sparse_chunk!(rows, cols, vals, stream, overflow_buf, n, batch_size)
             # Remove 0s from the end
             resize!(rows, count)
             resize!(cols, count)

--- a/src/sparse_nmf.jl
+++ b/src/sparse_nmf.jl
@@ -197,32 +197,7 @@ function update_spU_numer_ALPHA(input, N, M, U, V, alpha, chunksize)
             rows = zeros(UInt32, max_size)
             cols = zeros(UInt32, max_size)
             vals = zeros(UInt32, max_size)
-            count = 0
-            ############### Overflow buffer ###############
-            if length(overflow_buf) > 0
-                count += 1
-                # Re-mapping row index
-                rows[count] = overflow_buf[1] - n + 1
-                cols[count] = overflow_buf[2]
-                vals[count] = overflow_buf[3]
-                empty!(overflow_buf)
-            end
-            ###############################################
-            while !eof(stream)
-                buf = zeros(UInt32, 3)
-                read!(stream, buf)
-                row, col, val = buf[1], buf[2], buf[3]
-                if n ≤ row < n + batch_size
-                    count += 1
-                    # Re-mapping row index
-                    rows[count] = row - n + 1
-                    cols[count] = col
-                    vals[count] = val
-                else
-                    overflow_buf = buf
-                    break
-                end
-            end
+            count, overflow_buf = read_sparse_chunk!(rows, cols, vals, stream, overflow_buf, n, batch_size)
             # Remove 0s from the end
             resize!(rows, count)
             resize!(cols, count)
@@ -265,32 +240,7 @@ function update_spU_numer_BETA(input, N, M, U, V, beta, chunksize)
             rows = zeros(UInt32, max_size)
             cols = zeros(UInt32, max_size)
             vals = zeros(UInt32, max_size)
-            count = 0
-            ############### Overflow buffer ###############
-            if length(overflow_buf) > 0
-                count += 1
-                # Re-mapping row index
-                rows[count] = overflow_buf[1] - n + 1
-                cols[count] = overflow_buf[2]
-                vals[count] = overflow_buf[3]
-                empty!(overflow_buf)
-            end
-            ###############################################
-            while !eof(stream)
-                buf = zeros(UInt32, 3)
-                read!(stream, buf)
-                row, col, val = buf[1], buf[2], buf[3]
-                if n ≤ row < n + batch_size
-                    count += 1
-                    # Re-mapping row index
-                    rows[count] = row - n + 1
-                    cols[count] = col
-                    vals[count] = val
-                else
-                    overflow_buf = buf
-                    break
-                end
-            end
+            count, overflow_buf = read_sparse_chunk!(rows, cols, vals, stream, overflow_buf, n, batch_size)
             # Remove 0s from the end
             resize!(rows, count)
             resize!(cols, count)
@@ -348,32 +298,7 @@ function update_spV_numer_ALPHA(input, N, M, U, V, alpha, chunksize)
             rows = zeros(UInt32, max_size)
             cols = zeros(UInt32, max_size)
             vals = zeros(UInt32, max_size)
-            count = 0
-            ############### Overflow buffer ###############
-            if length(overflow_buf) > 0
-                count += 1
-                # Re-mapping row index
-                rows[count] = overflow_buf[1] - n + 1
-                cols[count] = overflow_buf[2]
-                vals[count] = overflow_buf[3]
-                empty!(overflow_buf)
-            end
-            ###############################################
-            while !eof(stream)
-                buf = zeros(UInt32, 3)
-                read!(stream, buf)
-                row, col, val = buf[1], buf[2], buf[3]
-                if n ≤ row < n + batch_size
-                    count += 1
-                    # Re-mapping row index
-                    rows[count] = row - n + 1
-                    cols[count] = col
-                    vals[count] = val
-                else
-                    overflow_buf = buf
-                    break
-                end
-            end
+            count, overflow_buf = read_sparse_chunk!(rows, cols, vals, stream, overflow_buf, n, batch_size)
             # Remove 0s from the end
             resize!(rows, count)
             resize!(cols, count)
@@ -430,32 +355,7 @@ function update_spV_numer_BETA(input, N, M, U, V, beta, chunksize)
             rows = zeros(UInt32, max_size)
             cols = zeros(UInt32, max_size)
             vals = zeros(UInt32, max_size)
-            count = 0
-            ############### Overflow buffer ###############
-            if length(overflow_buf) > 0
-                count += 1
-                # Re-mapping row index
-                rows[count] = overflow_buf[1] - n + 1
-                cols[count] = overflow_buf[2]
-                vals[count] = overflow_buf[3]
-                empty!(overflow_buf)
-            end
-            ###############################################
-            while !eof(stream)
-                buf = zeros(UInt32, 3)
-                read!(stream, buf)
-                row, col, val = buf[1], buf[2], buf[3]
-                if n ≤ row < n + batch_size
-                    count += 1
-                    # Re-mapping row index
-                    rows[count] = row - n + 1
-                    cols[count] = col
-                    vals[count] = val
-                else
-                    overflow_buf = buf
-                    break
-                end
-            end
+            count, overflow_buf = read_sparse_chunk!(rows, cols, vals, stream, overflow_buf, n, batch_size)
             # Remove 0s from the end
             resize!(rows, count)
             resize!(cols, count)

--- a/test/test_sparse_nmf.jl
+++ b/test/test_sparse_nmf.jl
@@ -48,6 +48,29 @@ out_chunk_odd = sparse_nmf(input=joinpath(tmp, "Data.mtx.zst"), dim=3, algorithm
 @test size(out_chunk_odd[2]) == (99, 3)
 @test size(out_chunk_odd[3]) == ()
 
+# Leading zero rows (regression test for #25). With chunks that fall before
+# the first non-zero row, the per-chunk overflow buffer must not be applied
+# to a chunk that doesn't actually contain its row. Before the fix this raised
+# either ArgumentError ("row indices I[k] must satisfy 1 <= I[k] <= m") or
+# InexactError(trunc, UInt32, ...) inside the chunk reader, regardless of the
+# divergence/algorithm chosen. We verify here that the chunk reader returns,
+# and that RecError (which exercises the same code path) returns a finite
+# value. Random initial U/V can later produce NaNs from rows that are all-zero
+# in X — that is a separate, pre-existing limitation of the multiplicative
+# update on zero rows and not what this regression is checking.
+leading_zero_data = sparse(copy(data))
+leading_zero_data[1:80, :] .= 0
+dropzeros!(leading_zero_data)
+mmwrite(joinpath(tmp_sparse_nmf_alpha, "LeadingZero.mtx"), leading_zero_data)
+mm2bin(mmfile=joinpath(tmp_sparse_nmf_alpha, "LeadingZero.mtx"), binfile=joinpath(tmp_sparse_nmf_alpha, "LeadingZero.mtx.zst"))
+let lz_input = joinpath(tmp_sparse_nmf_alpha, "LeadingZero.mtx.zst")
+    U_init = ones(Float32, 300, 3)
+    V_init = ones(Float32, 99, 3)
+    for cs in (1, 7, 50, 1000)
+        @test isfinite(OnlineNMF.RecError(lz_input, U_init, V_init, OnlineNMF.SPARSE_NMF(), cs))
+    end
+end
+
 # Extreme parameters
 @test_throws Exception sparse_nmf(input=joinpath(tmp, "Data.mtx.zst"), dim=3, graphv=-1, algorithm="alpha", chunksize=100)
 @test_throws Exception sparse_nmf(input=joinpath(tmp, "Data.mtx.zst"), dim=3, l1u=-1, algorithm="alpha", chunksize=100)


### PR DESCRIPTION
## Summary

Fixes #25. `sparse_nmf` (and the other COO-stream readers) failed with `BoundsError` / `ArgumentError("row indices I[k] must satisfy 1 <= I[k] <= m")` or `InexactError(trunc, UInt32, ...)` whenever the input had leading zero rows (or any gap larger than a chunk) — the symptoms varied only with `chunksize`.

### Root cause
The per-chunk overflow buffer was *unconditionally* drained at the top of every chunk iteration. If the buffered entry's row actually belonged to a much later chunk (because every chunk in between was empty), it was still rewritten as `overflow_buf[1] - n + 1` against the current chunk, producing an out-of-range or negative row index.

### Fix
Factor the chunk-reading loop into `read_sparse_chunk!` / `read_bincoo_chunk!` in `Utils.jl` and make consumption conditional on `n ≤ overflow_buf[1] < n + batch_size`. When the buffered entry belongs to a later chunk, return early without reading from the stream so the entry isn't overwritten and is preserved for the chunk that does contain it. Applied across all 11 call sites in `sparse_nmf.jl`, `sparse_dnmf.jl`, `bincoo_nmf.jl`, `bincoo_dnmf.jl`, and `Utils.RecError`. Net result is ~234 fewer lines (11 near-duplicates collapsed into 2 helpers).

### Note on a remaining limitation
Even after this fix, `sparse_nmf` on input with *fully*-zero rows can still hit `checkNaN` because the multiplicative update zeroes the corresponding rows of `U`, after which `0 / (U·V')` produces NaN in the next epoch. That is a separate, pre-existing algorithmic issue (the user's workaround using `+ 1e-4` / `+ 1e-10` epsilons confirms this). The regression test here targets the chunk-reader bug directly via `RecError` so the two issues aren't conflated; the NaN-on-zero-rows case can be tracked as a follow-up.

## Test plan

- [x] Existing `Pkg.test()` suite passes (NMF / DNMF / Sparse-NMF / Sparse-DNMF / BinCOO-NMF / BinCOO-DNMF, both Julia API and CLI).
- [x] New regression test in `test/test_sparse_nmf.jl`: builds a 300×99 matrix with rows 1:80 zeroed and calls `RecError` with `chunksize ∈ {1, 7, 50, 1000}`; verifies result is finite.
- [x] Reproducer from the issue (N=2000, M=100, first ~500 rows zero) now succeeds with default `chunksize=1`, with non-aligning `chunksize=200`, and with `chunksize=10000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)